### PR TITLE
send G0 instead of G1

### DIFF
--- a/src/UICompment/controlform.cpp
+++ b/src/UICompment/controlform.cpp
@@ -28,25 +28,25 @@ ControlForm::~ControlForm()
 void ControlForm::on_btnXp_clicked()
 {
     emit Sig_ToLaser(tr("G91"));
-    emit Sig_ToLaser(tr("G1 X-%1 F3000").arg(10));
+    emit Sig_ToLaser(tr("G0 X-%1 F3000").arg(10));
 }
 //X+
 void ControlForm::on_btnXa_clicked()
 {
     emit Sig_ToLaser(tr("G91"));
-    emit Sig_ToLaser(tr("G1 X%1 F3000").arg(10));
+    emit Sig_ToLaser(tr("G0 X%1 F3000").arg(10));
 }
 //Y+
 void ControlForm::on_btnYa_clicked()
 {
     emit Sig_ToLaser(tr("G91"));
-    emit Sig_ToLaser(tr("G1 Y%1 F3000").arg(10));
+    emit Sig_ToLaser(tr("G0 Y%1 F3000").arg(10));
 }
 //Y-
 void ControlForm::on_btnYp_clicked()
 {
     emit Sig_ToLaser(tr("G91"));
-    emit Sig_ToLaser(tr("G1 Y-%1 F3000").arg(10));
+    emit Sig_ToLaser(tr("G0 Y-%1 F3000").arg(10));
 }
 //Home
 void ControlForm::on_btnHome_clicked()


### PR DESCRIPTION
many firmwares switch the laser on when they receive a G1 command. The laser will not be turned on if the G0 command is issued. With the original Laserbot firmware, the device still does the same, thus this is a safe change.